### PR TITLE
Add cloudfront invalidation to deploy script

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -191,7 +191,7 @@ gulp.task(
                     ContentType:
                         type[(file.relative.match(/\.[^.]+/) || [""])[0]]
                 });
-            })
+            });
     })
 );
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -228,7 +228,6 @@ gulp.task("deploy", ["deploy-s3"], function(done) {
 
     Promise.all(invalidations)
         .then(function(data) {
-            console.log(data);
             done();
         })
         .catch(function(err) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -201,28 +201,29 @@ gulp.task("deploy", ["deploy-s3"], function(done) {
         "E1R9N0LC53KYI1", // ko
         "E2ZQ9P41RBE10E", // en
         "E3GHWCYV9EN104", // ja
-        "EP1V1GOZXRW4R"   // zh-tw
-    ].map(function (id) {
+        "EP1V1GOZXRW4R" // zh-tw
+    ].map(function(id) {
         return new Promise(function(resolve, reject) {
-            cloudfront.createInvalidation({
-                DistributionId: id,
-                InvalidationBatch: {
-                    CallerReference: time + id,
-                    Paths: {
-                        Quantity: 1,
-                        Items: [
-                            "/*"
-                        ]
+            cloudfront.createInvalidation(
+                {
+                    DistributionId: id,
+                    InvalidationBatch: {
+                        CallerReference: time + id,
+                        Paths: {
+                            Quantity: 1,
+                            Items: ["/*"]
+                        }
                     }
+                },
+                function(err, data) {
+                    if (err) {
+                        reject(err);
+                        return;
+                    }
+                    resolve(data);
                 }
-            }, function (err, data) {
-                if (err) {
-                    reject(err);
-                    return;
-                }
-                resolve(data);
-            });
-        })
+            );
+        });
     });
 
     Promise.all(invalidations)

--- a/package-lock.json
+++ b/package-lock.json
@@ -385,6 +385,11 @@
                 }
             }
         },
+        "bluebird": {
+            "version": "3.5.1",
+            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+            "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+        },
         "boom": {
             "version": "2.10.1",
             "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     },
     "dependencies": {
         "aws-sdk": "~2.0.31",
+        "bluebird": "~3.5.1",
         "bootstrap": "3.3.7",
         "del": "~1.1.0",
         "express": "4.14.0",


### PR DESCRIPTION
 - Add `bluebird` library to allow Promise usage (current node dependency doesn't support Promise)
 - After deploying to S3 create invalidation on all Cloudfront distributions